### PR TITLE
Attempt to fix the example

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,6 @@
+print_events.native: print_events.ml
+	ocamlfind ocamlopt -o test -package osx-fsevents,osx-fsevents.lwt,osx-cf.lwt,lwt.unix -linkpkg -thread print_events.ml 
+
+.PHONY: clean
+clean:
+	rm print_events.native

--- a/examples/print_events.ml
+++ b/examples/print_events.ml
@@ -19,9 +19,10 @@ let create_flags = Fsevents.CreateFlags.detailed_interactive
 
 let run_loop_mode = Cf.RunLoop.Mode.Default
 
-let watcher = Fsevents_lwt.watch 0. create_flags ["."]
+let watcher = Fsevents_lwt.create 0. create_flags ["."]
 
-let { Fsevents_lwt.event_stream; stream; } = watcher
+let stream = Fsevents_lwt.stream watcher
+let event_stream = Fsevents_lwt.event_stream watcher
 
 let string_of_event { Fsevents_lwt.path; flags } =
   path^"\n"^(Fsevents.EventFlags.to_string flags)


### PR DESCRIPTION
With this change it compiles but doesn't link:

```
cd examples
make
ocamlfind ocamlopt -o test -package osx-fsevents,osx-fsevents.lwt,osx-cf.lwt,lwt.unix -linkpkg -thread print_events.ml 
File "print_events.ml", line 1:
Error: Files /Users/djs/.opam/system/lib/osx-cf/cf_lwt.cmxa
       and /Users/djs/.opam/system/lib/osx-cf/cf.cmxa
       both define a module named Cf_types
```
