### PR TITLE
lwt.{preemptive,unix} findlib package updates

### DIFF
--- a/META
+++ b/META
@@ -8,7 +8,7 @@ archive(native, plugin) = "fsevents.cmxs"
 exists_if = "fsevents.cma"
 
 package "lwt" (
-  requires = "osx-fsevents lwt.preemptive"
+  requires = "osx-fsevents lwt.unix"
   archive(byte) = "fsevents_lwt.cma"
   archive(byte, plugin) = "fsevents_lwt.cma"
   archive(native) = "fsevents_lwt.cmxa"

--- a/lwt/_tags
+++ b/lwt/_tags
@@ -1,1 +1,1 @@
-<*.*>: package(lwt), package(osx-cf)
+<*.*>: package(lwt), package(lwt.unix), package(osx-cf)

--- a/opam
+++ b/opam
@@ -22,6 +22,6 @@ depends: [
   "cmdliner"
 ]
 depopts: [
-  "lwt"
+  "lwt" {>= "3.2.0"}
 ]
 available: [os = "darwin"]


### PR DESCRIPTION
As per https://github.com/ocsigen/lwt/issues/453 - in newer `lwt` versions, `Lwt_preemptive` lives in `lwt.unix` rather than its own `lwt.preemptive` package - this updates the references.